### PR TITLE
Support separate DB names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ services:
       HOURS_BETWEEN_PURGES: 24
       PG_HOST: lemmy_db_host
       PG_PORT: 5432
+      PG_DATABASE: lemmy
       PG_USERNAME: lemmy
       PG_PASSWORD: lemmy_db_password
     restart: unless-stopped
@@ -35,6 +36,7 @@ export PURGE_OLDER_THAN_DAYS=365
 export HOURS_BETWEEN_PURGES=24
 export PG_HOST=lemmy_db_host
 export PG_PORT=5432
+export PG_DATABASE=lemmy
 export PG_USERNAME=lemmy
 export PG_PASSWORD=lemmy_db_password
 npm install
@@ -52,5 +54,6 @@ npm start
 |HOURS_BETWEEN_PURGES|How long to wait between runs|
 |PG_HOST|Lemmy Postgres host|
 |PG_PORT|Lemmy Postgres port|
+|PG_DATABASE|Lemmy Postgres database name. Optional, and if not specified the username will be used as the database name|
 |PG_USERNAME|Lemmy Postgres user name|
 |PG_PASSWORD|Lemmy Postgres password|

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const purgeOlderThanDays = parseInt(process.env.PURGE_OLDER_THAN_DAYS);
 const hoursBetweenPurges = parseInt(process.env.HOURS_BETWEEN_PURGES);
 
 const pgHost = process.env.PG_HOST;
+const pgDatabase = process.env.PG_DATABASE ?? process.env.PG_USERNAME;
 const pgPort = process.env.PG_PORT;
 const pgUsername = process.env.PG_USERNAME;
 const pgPassword = process.env.PG_PASSWORD;
@@ -15,6 +16,7 @@ const pgPassword = process.env.PG_PASSWORD;
 const pool = new Pool({
   host: pgHost,
   port: pgPort,
+  database: pgDatabase,
   user: pgUsername,
   password: pgPassword,
   max: 20,


### PR DESCRIPTION
Adds a new config env variable to supply a database name separately.

The `pg` module defaults to using the username for the database name, but this isn't always desired. For example, I have a separate DB user for this script with only `SELECT` permissions for security reasons, but its username is not the same as the Lemmy database itself.